### PR TITLE
Fix atomic.AddInt64 not work on x86_32 or ARM

### DIFF
--- a/app/builder/compile.go
+++ b/app/builder/compile.go
@@ -230,7 +230,7 @@ func compile(ctx *Context, file string, viewData map[string]interface{}, destFil
 	}
 	ctx.Sync.SetSynced(destFile)
 	log15.Debug("Build|%s", filepath.ToSlash(destFile))
-	atomic.AddInt64(&ctx.counter, 1)
+	atomic.AddInt32(&ctx.counter, 1)
 	return nil
 }
 
@@ -280,7 +280,7 @@ func compileRSS(ctx *Context) error {
 	}
 	ctx.Sync.SetSynced(dstFile)
 	log15.Debug("Build|%s", dstFile)
-	atomic.AddInt64(&ctx.counter, 1)
+	atomic.AddInt32(&ctx.counter, 1)
 	return nil
 }
 
@@ -347,6 +347,6 @@ func compileSitemap(ctx *Context) error {
 	}
 	ctx.Sync.SetSynced(dstFile)
 	log15.Debug("Build|%s", dstFile)
-	atomic.AddInt64(&ctx.counter, 1)
+	atomic.AddInt32(&ctx.counter, 1)
 	return nil
 }

--- a/app/builder/context.go
+++ b/app/builder/context.go
@@ -40,7 +40,7 @@ type (
 		Sync *sync.Syncer
 
 		time           time.Time
-		counter        int64
+		counter        int32
 		srcDir, dstDir string
 	}
 )
@@ -108,7 +108,7 @@ func (ctx *Context) Duration() float64 {
 // Again reset some fields in context to rebuild
 func (ctx *Context) Again() {
 	ctx.time = time.Now()
-	atomic.StoreInt64(&ctx.counter, 0)
+	atomic.StoreInt32(&ctx.counter, 0)
 }
 
 // SrcDir get src dir

--- a/app/helper/worker_test.go
+++ b/app/helper/worker_test.go
@@ -10,13 +10,13 @@ import (
 )
 
 func TestWorker(t *testing.T) {
-	var a int64 = 1
+	var a int32 = 1
 	normalFn := func() error {
-		atomic.AddInt64(&a, 1)
+		atomic.AddInt32(&a, 1)
 		return nil
 	}
 	errorFn := func() error {
-		atomic.AddInt64(&a, 1)
+		atomic.AddInt32(&a, 1)
 		return errors.New("error")
 	}
 


### PR DESCRIPTION
根据Golang的官方文档，atomic.AddInt64在32位机以及ARM平台上有BUG，会导致panic。
Golang的官方说法需要调用者自行处理。

看了下代码，这里的counter用int64和int32应该都可以，这样修改起来也比较简单。